### PR TITLE
Switch to ggplot 3.3 after_stat and 3.4 dropped_aes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: deps
-      uses: r-lib/ghactions/actions/install-deps@v0.4.1
-    - name: checks
-      uses: r-lib/ghactions/actions/check@v0.4.1
+    - uses: r-lib/actions/setup-r@v2
+    - uses: r-lib/actions/setup-r-dependencies@v2
+      with:
+        cache-version: 2
+        extra-packages: any::rcmdcheck
+        needs: check
+    - uses: r-lib/actions/check-r-package@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,5 +17,5 @@ BugReports: https://github.com/flying-sheep/ggplot.multistats/issues
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-Imports: methods, rlang, scales, hexbin, ggplot2 (>=3.3.0)
+Imports: methods, rlang, scales, hexbin, ggplot2 (>= 3.3.0)
 RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggplot.multistats
 Title: Multiple Summary Statistics for Binned Stats/Geometries
 Version: 1.0.0
-Authors@R: 
+Authors@R:
     person(given = "Philipp",
            family = "Angerer",
            role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,5 +17,5 @@ BugReports: https://github.com/flying-sheep/ggplot.multistats/issues
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-Imports: methods, rlang, scales, hexbin, ggplot2
-RoxygenNote: 7.0.0
+Imports: methods, rlang, scales, hexbin, ggplot2 (>=3.3.0)
+RoxygenNote: 7.2.3

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 GNU General Public License
 ==========================
 
-_Version 3, 29 June 2007_  
+_Version 3, 29 June 2007_
 _Copyright © 2007 Free Software Foundation, Inc. &lt;<http://fsf.org/>&gt;_
 
 Everyone is permitted to copy and distribute verbatim copies of this license

--- a/R/stat_summaries_hex.r
+++ b/R/stat_summaries_hex.r
@@ -18,11 +18,11 @@
 #' library(ggplot2)
 #' # Define the variable used for the stats using z
 #' ggplot_base <- ggplot(iris, aes(Sepal.Width, Sepal.Length, z = Petal.Width))
-#' # The default is creating `stat(value)` containing the mean
-#' ggplot_base + stat_summaries_hex(aes(fill = stat(value)), bins = 5)
+#' # The default is creating `after_stat(value)` containing the mean
+#' ggplot_base + stat_summaries_hex(aes(fill = after_stat(value)), bins = 5)
 #' # but you can specify your own stats
 #' ggplot_base + stat_summaries_hex(
-#'   aes(fill = stat(median), alpha = stat(n)),
+#'   aes(fill = after_stat(median), alpha = after_stat(n)),
 #'   funs = c('median', n = 'length'),
 #'   bins = 5)
 #'
@@ -63,8 +63,9 @@ stat_summaries_hex <- function(
 StatSummariesHex <- ggproto(
 	'StatSummariesHex',
 	Stat,
-	#default_aes = aes(fill = stat(value)),
+	#default_aes = aes(fill = after_stat(value)),
 	required_aes = c('x', 'y', 'z'),
+	dropped_aes = c('z'),
 	compute_group = function(
 		data, scales,
 		binwidth = NULL, bins = 30,
@@ -77,7 +78,7 @@ StatSummariesHex <- ggproto(
 		funs <- as.list(normalize_function_list(funs))  # if it was no list before, adding a function makes it one
 		funs$`_dummy` <- function(x) 1  # hexBinSummarise ruins our day if we have less than two items in the list
 		idx_dummy <- names(funs) %in% '_dummy'
-		if (sum(idx_dummy) > 1L) stop('You cannot name a function `_dummy_, sorry.')
+		if (sum(idx_dummy) > 1L) stop('You cannot name a function `_dummy`, sorry.')
 
 		fun <- function(x) sapply(funs, exec, x, simplify = FALSE)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ devtools::install_github('flying-sheep/ggplot.multistats')
 Example
 -------
 Specify a summary variable using the `z` aesthetic
-and specify a list of `funs` to provide `stat`s for you:
+and specify a list of `funs` to provide `after_stat`s for you:
 
 ```r
 library(ggplot2)
@@ -34,7 +34,7 @@ library(ggplot.multistats)
 
 ggplot(iris, aes(Sepal.Width, Sepal.Length)) +
   stat_summaries_hex(
-    aes(z = Petal.Width, fill = stat(median), alpha = stat(n)),
+    aes(z = Petal.Width, fill = after_stat(median), alpha = after_stat(n)),
     funs = c('median', n = 'length'),
     bins = 5
   )

--- a/man/stat_summaries_hex.Rd
+++ b/man/stat_summaries_hex.Rd
@@ -4,7 +4,9 @@
 \alias{stat_summaries_hex}
 \alias{StatSummariesHex}
 \title{Multi-Stat Binning Layer}
-\format{An object of class \code{StatSummariesHex} (inherits from \code{Stat}, \code{ggproto}, \code{gg}) of length 3.}
+\format{
+An object of class \code{StatSummariesHex} (inherits from \code{Stat}, \code{ggproto}, \code{gg}) of length 4.
+}
 \usage{
 stat_summaries_hex(
   mapping = NULL,
@@ -25,32 +27,36 @@ stat_summaries_hex(
 StatSummariesHex
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
-\code{\link[=aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
-default), it is combined with the default mapping at the top level of the
-plot. You must supply \code{mapping} if there is no plot mapping.}
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}}. If specified and
+\code{inherit.aes = TRUE} (the default), it is combined with the default mapping
+at the top level of the plot. You must supply \code{mapping} if there is no plot
+mapping.}
 
 \item{data}{The data to be displayed in this layer. There are three
 options:
 
 If \code{NULL}, the default, the data is inherited from the plot
-data as specified in the call to \code{\link[=ggplot]{ggplot()}}.
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
 A \code{data.frame}, or other object, will override the plot
 data. All objects will be fortified to produce a data frame. See
-\code{\link[=fortify]{fortify()}} for which variables will be created.
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
 the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
-\item{geom}{The geometric object to use display the data}
+\item{geom}{The geometric object to use to display the data, either as a
+\code{ggproto} \code{Geom} subclass or as a string naming the geom stripped of the
+\code{geom_} prefix (e.g. \code{"point"} rather than \code{"geom_point"})}
 
-\item{position}{Position adjustment, either as a string, or the result of
-a call to a position adjustment function.}
+\item{position}{Position adjustment, either as a string naming the adjustment
+(e.g. \code{"jitter"} to use \code{position_jitter}), or the result of a call to a
+position adjustment function. Use the latter if you need to change the
+settings of the adjustment.}
 
-\item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
+\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
 \code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
@@ -78,7 +84,7 @@ display.}
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
 \item{key_glyph}{A legend key drawing function or a string providing
 the function name minus the \code{draw_key_} prefix.
@@ -92,11 +98,11 @@ for multiple stats to be captured using the \code{funs} parameter.
 library(ggplot2)
 # Define the variable used for the stats using z
 ggplot_base <- ggplot(iris, aes(Sepal.Width, Sepal.Length, z = Petal.Width))
-# The default is creating `stat(value)` containing the mean
-ggplot_base + stat_summaries_hex(aes(fill = stat(value)), bins = 5)
+# The default is creating `after_stat(value)` containing the mean
+ggplot_base + stat_summaries_hex(aes(fill = after_stat(value)), bins = 5)
 # but you can specify your own stats
 ggplot_base + stat_summaries_hex(
-  aes(fill = stat(median), alpha = stat(n)),
+  aes(fill = after_stat(median), alpha = after_stat(n)),
   funs = c('median', n = 'length'),
   bins = 5)
 


### PR DESCRIPTION
Fixes #2

- ggplot 3.3 replaces `stat` with `after_stat`: https://ggplot2.tidyverse.org/news/#new-features-3-3-0
- ggplot 3.4 warns if dropped aesthetics aren’t specified: https://ggplot2.tidyverse.org/news/#new-features-3-4-0